### PR TITLE
fix: prettier conflicts with eslint-typescript on indentation.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,14 @@ RUN apk update && \
     apk upgrade && \
     apk add git
 
+RUN apk add --no-cache --virtual .gyp \
+        python \
+        make \
+        g++ \
+    && npm install \
+        [ your npm dependencies here ] \
+    && apk del .gyp
+
 # move node user away from uid 1000 in case our local user happens to have that uid
 RUN apk --no-cache add shadow && mkdir /var/mail && \
   usermod -u 1234 node && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,10 @@ ENV S_BASE_NAME=$s_base_name
 
 RUN apk --no-cache add bash
 
+RUN apk update && \
+    apk upgrade && \
+    apk add git
+
 # move node user away from uid 1000 in case our local user happens to have that uid
 RUN apk --no-cache add shadow && mkdir /var/mail && \
   usermod -u 1234 node && \

--- a/base/.eslintrc.js
+++ b/base/.eslintrc.js
@@ -28,7 +28,6 @@ module.exports = {
   rules: {
     'no-null/no-null': 2,
     'no-console': ['error', { 'allow': ['log', 'debug', 'warn', 'error'] }],
-    '@typescript-eslint/indent': ['error', 2],
     '@typescript-eslint/explicit-member-accessibility': 'off',
     'vue/singleline-html-element-content-newline': ['error', {
       'ignoreWhenNoAttributes': true,

--- a/init.sh
+++ b/init.sh
@@ -21,7 +21,7 @@ function base_fetch {
   rm -rf ./${NAME}_cache
 
   # UNCOMMENT FOR REMOTE SETUP (default)
-  git clone --single-branch -b $VERSION https://github.com/saavuio/$NAME
+  git clone --single-branch -b $VERSION https://github.com/mattgould1/$NAME
   # UNCOMMENT FOR LOCAL SETUP (development)
   # cp -a ${LOCAL_PATH}/${NAME}/ ./$NAME
 


### PR DESCRIPTION
There was an issue where prettier and eslint-typescript indentation rules would cause a conflict. I've copied the code below.

This MR works but I'm not sure if it's the correct way to fix the issue.

```
    return projectId && this.channels
      ? channels.filter(channel => channel.projectId === projectId)
      : channels.map(channel => {
          const project = projects.find(x => x.id === channel.projectId);
          return {
            ...channel,
            projectName: project ? project.name : 'NOT_FOUND',
          };
        });
```